### PR TITLE
Improved find script.

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -231,7 +231,7 @@ fi
 
 # create the Payload.ipa file
 # we don't have the config name so using *, assuming that there will be only one
-test_runner_path=$(find "build/Build/Products/"*"-iphoneos/${scheme}-Runner.app" -print -quit)
+test_runner_path=$(find "build/Build/Products/"*"-iphoneos/${scheme}"*"-Runner.app" -print -quit)
 if [ $? != 0 ] ; then
   echo "out: $test_runner_path"
   exit 1


### PR DESCRIPTION
The purpose of this PR is to support different app names. Using Xcode 9.4.1 my app was generated like shcemeUITests-Runner, so I was unable to make this work with this change now it's working properly.