### PR TITLE
Force code signing to not happen

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -201,7 +201,7 @@ if [ ! -z "${configuration}" ] ; then
 	archive_cmd="$archive_cmd -configuration \"${configuration}\""
 fi
 
-archive_cmd="$archive_cmd build-for-testing -derivedDataPath ./build CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO"
+archive_cmd="$archive_cmd build-for-testing -derivedDataPath ./build CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO"
 
 
 


### PR DESCRIPTION
*Issue*
In newer versions of Xcode, code signing happens:
_"error: An empty identity is not valid when signing a binary for the product type 'UI Testing Bundle'. (in target 'Scheme' from project 'Project')"_

*Resolution*
Add `CODE_SIGNING_ALLOWED=NO` to the `xcodebuild` command.